### PR TITLE
Fix opening dialogs through open attribute

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -59,7 +59,7 @@ if (!window.HTMLDialogElement) {
             return this.hasAttribute('open');
         },
         set(value){
-            value ? this.open() : this.close();
+            value ? this.show() : this.close();
         }
     })
 


### PR DESCRIPTION
this.open() does not exist, the proper method name is this.show()